### PR TITLE
Actually download FASTFETCH, build as user & correctly install all files

### DIFF
--- a/btop.conf
+++ b/btop.conf
@@ -57,7 +57,7 @@ update_ms = 600
 
 #* Processes sorting, "pid" "program" "arguments" "threads" "user" "memory" "cpu lazy" "cpu direct",
 #* "cpu lazy" sorts top process over time (easier to follow), "cpu direct" updates top process directly.
-proc_sorting = "cpu lazy"
+proc_sorting = "memory"
 
 #* Reverse sorting order, True or False.
 proc_reversed = False

--- a/fastfetch-autocompile.sh
+++ b/fastfetch-autocompile.sh
@@ -21,16 +21,16 @@ elif [ "${UID}" -ne 0 ]; then
 fi
 
 # Download the newest releases source code in .tar.gz form for the time being.
-#baseurl="https://github.com/fastfetch-cli/fastfetch/releases"
-#ver=$(basename "$(curl -w "%{url_effective}\n" -I -L -s -S $baseurl/latest -o /dev/null)")
-#curl -fLO "https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/2.32.1.tar.gz" 
+baseurl="https://github.com/fastfetch-cli/fastfetch/releases"
+ver=$(basename "$(curl -w "%{url_effective}\n" -I -L -s -S $baseurl/latest -o /dev/null)")
+curl -fL "https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/$ver.tar.gz" -o "fastfetch-$ver.tar.gz"
 
 # Decompressing, Extracting & Changing Directories.
 gunzip fastfetch-*.tar.gz
 tar -xf fastfetch-*.tar
 cd fastfetch-*/
 
-# Download Build-dependancies
+# Download Build-dependencies
 if which apt-get &> /dev/null; then
 	$PRIVILEGES apt-get update
 	$PRIVILEGES apt-get install -y cmake pkg-config build-essential 
@@ -39,12 +39,11 @@ else
 fi
 
 # Compiling
-$PRIVILEGES cmake .
-$PRIVILEGES cmake --build . --target fastfetch -j$(nproc)
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr 
+cmake --build build -j$(nproc)
 
-# Replacing old fastfetch binary & manual page
-$PRIVILEGES mv -v fastfetch /usr/bin
-$PRIVILEGES mv -v fastfetch.1 /usr/share/man/man1
+# Installing
+$PRIVILEGES cmake --install build
 
 echo "
 ▗▄▄▄▖▗▄▄▄▖▗▖  ▗▖▗▄▄▄▖ ▗▄▄▖▗▖ ▗▖▗▄▄▄▖▗▄▄▄ 
@@ -53,4 +52,4 @@ echo "
 ▐▌   ▗▄█▄▖▐▌  ▐▌▗▄█▄▖▗▄▄▞▘▐▌ ▐▌▐▙▄▄▖▐▙▄▄▀
 "
 
-# ToDo: 1. Add Build-dependancies, 2. Download newest Fastfetch source code automaticly
+# ToDo: 1. Add Build-dependencies

--- a/fastfetch-autocompile.sh
+++ b/fastfetch-autocompile.sh
@@ -13,14 +13,14 @@ echo "
 -----------------------------------------------------------------------------------------------------
 "
 
-# Permissions ;-) (sudo or not) # Including Bashisms?
+# Permissions ;-) (sudo or not) | Including Bashisms?
 if [ "$UID" = 1000 ]; then         
 	PRIVILEGES="sudo"
 elif [ "${UID}" -ne 0 ]; then 
 	PRIVILEGES=""
 fi
 
-# Download the newest releases source code in .tar.gz form for the time being.
+# Downloading the newest release source code in *.tar.gz form.
 baseurl="https://github.com/fastfetch-cli/fastfetch/releases"
 ver=$(basename "$(curl -w "%{url_effective}\n" -I -L -s -S $baseurl/latest -o /dev/null)")
 curl -fL "https://github.com/fastfetch-cli/fastfetch/archive/refs/tags/$ver.tar.gz" -o "fastfetch-$ver.tar.gz"
@@ -39,7 +39,7 @@ else
 fi
 
 # Compiling
-cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr 
+cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local 
 cmake --build build -j$(nproc)
 
 # Installing
@@ -52,4 +52,4 @@ echo "
 ▐▌   ▗▄█▄▖▐▌  ▐▌▗▄█▄▖▗▄▄▞▘▐▌ ▐▌▐▙▄▄▖▐▙▄▄▀
 "
 
-# ToDo: 1. Add Build-dependencies
+# ToDo: Nothing, for the time being ;-)


### PR DESCRIPTION
Hey, habe dein Script gesehen und es mal schnell gefixt.
Es wird jetzt richtig heruntergeladen, mit Userrechten als Release gebuilded und richtig installiert. (deine alte Methode hat z.B. flashfetch und die Shell completions nicht mit installiert)

Beim `-DCMAKE_INSTALL_PREFIX=/usr` kannst du entscheiden ob du es drin lässt. Sonst wird es nach `/usr/local` installiert was eigentlich passender ist für Programme die man nicht mit dem package manager installiert hat.